### PR TITLE
Folders plugin and multibranch pipeline friendliness

### DIFF
--- a/src/main/java/hudson/plugins/analysis/collector/AnalysisProjectAction.java
+++ b/src/main/java/hudson/plugins/analysis/collector/AnalysisProjectAction.java
@@ -51,6 +51,7 @@ public class AnalysisProjectAction extends AbstractProjectAction<AnalysisResultA
                 AnalysisDescriptor.isPmdInstalled(),
                 AnalysisDescriptor.isOpenTasksInstalled(),
                 AnalysisDescriptor.isWarningsInstalled());
+        warningsAggregator.hideJobPrefix();
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/collector/AnalysisProjectAction.java
+++ b/src/main/java/hudson/plugins/analysis/collector/AnalysisProjectAction.java
@@ -51,7 +51,6 @@ public class AnalysisProjectAction extends AbstractProjectAction<AnalysisResultA
                 AnalysisDescriptor.isPmdInstalled(),
                 AnalysisDescriptor.isOpenTasksInstalled(),
                 AnalysisDescriptor.isWarningsInstalled());
-        warningsAggregator.hideJobPrefix();
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/collector/WarningsAggregator.java
+++ b/src/main/java/hudson/plugins/analysis/collector/WarningsAggregator.java
@@ -30,6 +30,7 @@ public class WarningsAggregator {
     private final boolean isPmdActivated;
     private final boolean isOpenTasksActivated;
     private final boolean isWarningsActivated;
+    private boolean hideJobPrefix;
 
     /**
      * Creates a new instance of {@link WarningsAggregator}.
@@ -258,7 +259,7 @@ public class WarningsAggregator {
     }
 
     private String getJobPrefix(final Job<?, ?> job) {
-        return job.getAbsoluteUrl();
+        return hideJobPrefix ? StringUtils.EMPTY : job.getAbsoluteUrl();
     }
 
     /**
@@ -351,4 +352,10 @@ public class WarningsAggregator {
         return action != null && action.hasValidResults();
     }
 
+    /**
+     * Removes the job/job-name prefix in the URL.
+     */
+    public void hideJobPrefix() {
+        hideJobPrefix = true;
+    }
 }

--- a/src/main/java/hudson/plugins/analysis/collector/WarningsAggregator.java
+++ b/src/main/java/hudson/plugins/analysis/collector/WarningsAggregator.java
@@ -30,7 +30,6 @@ public class WarningsAggregator {
     private final boolean isPmdActivated;
     private final boolean isOpenTasksActivated;
     private final boolean isWarningsActivated;
-    private boolean hideJobPrefix;
 
     /**
      * Creates a new instance of {@link WarningsAggregator}.
@@ -259,7 +258,7 @@ public class WarningsAggregator {
     }
 
     private String getJobPrefix(final Job<?, ?> job) {
-        return hideJobPrefix ? StringUtils.EMPTY : job.getShortUrl();
+        return job.getAbsoluteUrl();
     }
 
     /**
@@ -352,10 +351,4 @@ public class WarningsAggregator {
         return action != null && action.hasValidResults();
     }
 
-    /**
-     * Removes the job/job-name prefix in the URL.
-     */
-    public void hideJobPrefix() {
-        hideJobPrefix = true;
-    }
 }


### PR DESCRIPTION
This PR changes `getShortUrl` to `getAbsoluteUrl` to make this plugin friendly to Folders plugin, multibranch pipeline plugin (that uses Folders plugin) and Dashboard plugin by preventing HTTP 404 status codes while trying to access incorrectly generated job actions urls (i.e. warnings, etc).